### PR TITLE
fix: Merge steps in menu test to avoid race condition

### DIFF
--- a/cypress/e2e/1216-menu/user-sees-menu.feature
+++ b/cypress/e2e/1216-menu/user-sees-menu.feature
@@ -9,14 +9,13 @@ Feature: User sees menu
 
     @test
     Scenario: User have option to log out
-        Given that the user is logged in
+        Given a user is logged in
         When they look at any page in NVA
         Then they have an option to log out
 
     @test
     Scenario: User without any role sees menu
-        Given that the user is logged in
-        And they have no NVA role
+        Given a user without any NVA role is logged in
         When they look at any page in NVA
         Then they see Menu items:
             | My page |
@@ -24,8 +23,7 @@ Feature: User sees menu
 
     @test
     Scenario: User sees the menu for Creator
-        Given that the user is logged in
-        And they have the "Creator" role
+        Given a user with the "Creator" role is logged in
         When they look at any page in NVA
         Then they see Menu items:
             | My page |
@@ -33,8 +31,7 @@ Feature: User sees menu
 
     @test
     Scenario: User sees the menu for Curator
-        Given that the user is logged in
-        And they have the "Curator" Role
+        Given a user with the "Curator" role is logged in
         When they look at any page in NVA
         Then they see Menu items:
             | Worklist |
@@ -43,8 +40,7 @@ Feature: User sees menu
 
     @test
     Scenario: User sees the menu for Institution-admin
-        Given that the user is logged in
-        And they have the "Institution-admin" role
+        Given a user with the "Institution-admin" role is logged in
         When they look at any page in NVA
         Then they see Menu items:
             | Basic data |
@@ -53,8 +49,7 @@ Feature: User sees menu
 
     @test
     Scenario: User sees the menu for Editor
-        Given that the user is logged in
-        And they have the "Editor" role
+        Given a user with the "Editor" role is logged in
         When they look at any page in NVA
         Then they see Menu items:
             | My page    |
@@ -62,8 +57,7 @@ Feature: User sees menu
 
     @test
     Scenario: User sees the menu for Application administrator
-        Given that the user is logged in
-        And they have the "App-admin" role
+        Given a user with the "App-admin" role is logged in
         When they look at any page in NVA
         Then they see Menu items:
             | Basic data |

--- a/cypress/e2e/1216-menu/user-sees-menu/user-sees-menu.ts
+++ b/cypress/e2e/1216-menu/user-sees-menu/user-sees-menu.ts
@@ -7,21 +7,34 @@ import {
   userUnitEditor,
   userUnitWithAuthor,
 } from '../../../support/constants';
-import {
-  adminMenu,
-  creatorMenu,
-  curatorMenu,
-  instAdminMenu,
-  mainButtons,
-  userMenu,
-} from '../../../support/data_testid_constants';
+import { mainButtons } from '../../../support/data_testid_constants';
 import { dataTestId } from '../../../support/dataTestIds';
 import { Given, When, Then, DataTable } from '@badeball/cypress-cucumber-preprocessor';
 
 // Feature: User sees menu
 
+const userForRole: Record<string, string> = {
+  Creator: userUnitTestMenu,
+  Curator: userUnitCurator,
+  'Institution-admin': userUnitInstAdmin,
+  Editor: userUnitEditor,
+  'App-admin': adminUserUnit,
+};
+
 // Common steps
-Given('that the user is logged in', () => {});
+Given('a user is logged in', () => {
+  cy.login(userUnitWithAuthor);
+});
+Given('a user without any NVA role is logged in', () => {
+  cy.login(userUnitNoRole);
+});
+Given('a user with the {string} role is logged in', (role: string) => {
+  const userId = userForRole[role];
+  if (!userId) {
+    throw new Error(`No test user configured for role "${role}"`);
+  }
+  cy.login(userId);
+});
 When('they look at any page in NVA', () => {
   cy.visit(`/`, {
     auth: {
@@ -55,43 +68,6 @@ Then('they see the Log in Button', () => {
 
 // Scenario: User have option to log out
 Then('they have an option to log out', () => {
-  cy.login(userUnitWithAuthor);
-  cy.getDataTestId(dataTestId.header.menuButton).should('exist');
-  cy.getDataTestId(dataTestId.header.menuButton).click();
+  cy.getDataTestId(dataTestId.header.menuButton).should('be.visible').click();
   cy.getDataTestId(dataTestId.header.logOutLink).should('be.visible');
-});
-
-// Scenario: User without any role sees menu
-Given('they have no NVA role', () => {
-  cy.login(userUnitNoRole);
-  cy.wrap(userMenu).as('MENU');
-});
-
-// Scenario: User sees the menu for Creator
-Given('they have the "Creator" role', () => {
-  cy.login(userUnitTestMenu);
-  cy.wrap(creatorMenu).as('MENU');
-});
-
-// Scenario: User sees the menu for Curator
-Given('they have the "Curator" Role', () => {
-  cy.login(userUnitCurator);
-  cy.wrap(curatorMenu).as('MENU');
-});
-
-// Scenario: User sees the menu for Institution-admin
-Given('they have the "Institution-admin" role', () => {
-  cy.login(userUnitInstAdmin);
-  cy.wrap(instAdminMenu).as('MENU');
-});
-
-Given('they have the "Editor" role', () => {
-  cy.login(userUnitEditor);
-  cy.wrap(instAdminMenu).as('MENU');
-});
-
-// Scenario: User sees the menu for Application administrator
-Given('they have the "App-admin" role', () => {
-  cy.login(adminUserUnit);
-  cy.wrap(adminMenu).as('MENU');
 });

--- a/cypress/support/data_testid_constants.ts
+++ b/cypress/support/data_testid_constants.ts
@@ -8,29 +8,9 @@ export const mainButtons = {
   'Basic data': dataTestId.header.basicDataLink,
 };
 
-export const userMenu = {
-  'Log out': dataTestId.header.logOutLink,
-};
-
 export const myRegistrationsTabs = {
   Draft: 'unpublished-button',
   Published: 'published-button',
-};
-
-export const creatorMenu = {
-  ...userMenu,
-};
-
-export const curatorMenu = {
-  ...userMenu,
-};
-
-export const instAdminMenu = {
-  ...userMenu,
-};
-
-export const adminMenu = {
-  ...userMenu,
 };
 
 export const profilePageFields = {


### PR DESCRIPTION
Changes:

- Removes `cy.login` from `Then`-step which caused race condition-issues
- Removes unused `cy.wrap` from steps
- Merges steps into a single parameterized `logged in as <role>` step

Note that this diff is a bit noisy because of mismatched line-endings (accidentally converted to Unix-style). Use "Hide whitespace" in the GitHub diff viewer to see actual changes.