### PR TITLE
fix: Add custom preprocessor plugin to handle failure states

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'cypress';
 import createBundler from '@bahmutov/cypress-esbuild-preprocessor';
-import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-preprocessor';
+import { addCucumberPreprocessorPlugin, afterSpecHandler } from '@badeball/cypress-cucumber-preprocessor';
 import { createEsbuildPlugin } from '@badeball/cypress-cucumber-preprocessor/esbuild';
 
 export default defineConfig({
@@ -21,7 +21,19 @@ export default defineConfig({
       config: Cypress.PluginConfigOptions
     ): Promise<Cypress.PluginConfigOptions> {
       // This is required for the preprocessor to be able to generate JSON reports after each run, and more,
-      await addCucumberPreprocessorPlugin(on, config);
+      await addCucumberPreprocessorPlugin(on, config, { omitAfterSpecHandler: true });
+
+      on('after:spec', async (spec, results) => {
+        try {
+          await afterSpecHandler(config, spec, results);
+        } catch (error) {
+          // A failed BeforeAll/AfterAll leaves the preprocessor in the "run-hook-started" state,
+          // making afterSpecHandler throw and crash the plugins process before spec results reach
+          // Cypress Cloud, which then shows the spec as "running" until pipeline timeout.
+          // Swallow the error so the spec is reported as a normal failure instead.
+          console.error(`cucumber afterSpecHandler failed for ${spec.relative}:`, error);
+        }
+      });
 
       on(
         'file:preprocessor',


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-51497

Adds a custom preprocessor that wraps the default preprocessor in a try/catch, so that we can fail gracefully when a BeforeAll/AfterAll fails instead of leaving the pipeline running until timeout.