### PR TITLE
feat: Add GitHub workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,12 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: 'monday'
+      time: '07:00'
+      timezone: Europe/Oslo
   - package-ecosystem: npm
     directory: '/'
     schedule:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,9 +9,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,13 +21,14 @@ jobs:
         env:
           CYPRESS_INSTALL_BINARY: '0'
 
+      - name: Install cfn-lint
+        run: pipx install cfn-lint
+
       - name: Typecheck
-        run: npx tsc --noEmit
+        run: npm run typecheck
 
       - name: Lint CloudFormation template
-        run: |
-          pipx install cfn-lint
-          cfn-lint template/e2e_pipeline_template.yml
+        run: npm run lint:cfn
 
       - name: Shellcheck
-        run: shellcheck run-tests.sh
+        run: npm run lint:shell

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [test-deploy]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Lint CloudFormation template
+        run: |
+          pipx install cfn-lint
+          cfn-lint template/e2e_pipeline_template.yml
+
+      - name: Shellcheck
+        run: shellcheck run-tests.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,9 @@ jobs:
           CYPRESS_INSTALL_BINARY: '0'
 
       - name: Install cfn-lint
-        run: pipx install cfn-lint
+        run: |
+          pipx install cfn-lint==1.53.3
+          cfn-lint --version
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,16 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:
     branches: [test-deploy]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ aws sso login --sso-session sikt
 Run `./run-tests.sh -h` for all options.
 Every `CYPRESS_*` variable is only fetched when not already set, so any of them can be overridden by exporting it before running the script.
 
+## Static checks
+
+The GitHub Actions lint workflow (`.github/workflows/lint.yml`) runs static checks on every pull request.
+The same checks can be run locally through npm scripts, which are the single source of truth for what each check does:
+
+```bash
+npm run check         # run all checks
+npm run typecheck     # tsc --noEmit
+npm run lint:cfn      # cfn-lint on the pipeline template
+npm run lint:shell    # shellcheck on run-tests.sh
+```
+
+`lint:cfn` and `lint:shell` need system binaries: `brew install cfn-lint shellcheck`.
+
 ## Deploying the pipeline stack
 
 The pipeline template (`template/e2e_pipeline_template.yml`) has no CI/CD of its own.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "create:cucumber:report": "node scripts/cucumber_report.mjs",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "typecheck": "tsc --noEmit",
+    "lint:cfn": "cfn-lint template/e2e_pipeline_template.yml",
+    "lint:shell": "shellcheck run-tests.sh",
+    "check": "npm run typecheck && npm run lint:cfn && npm run lint:shell"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Adds a minimal GitHub workflow that runs on pull requests and merges to main. The same checks can be run locally with `npm run check` if the required tools are available (`cfn-lint` and `shellcheck`).